### PR TITLE
compile_fw & omnia-rescue: add dropbear, fix image size calculation

### DIFF
--- a/compile_fw
+++ b/compile_fw
@@ -309,7 +309,12 @@ elif [ "$TARGET_BOARD" = omnia ]; then
 	cat build_dir/target-arm_cortex-a9+vfpv3_musl-*_eabi/linux-mvebu/linux-4.4*/arch/arm/boot/dts/armada-385-turris-omnia.dtb >> `ls -d build_dir/target-arm_cortex-a9+vfpv3_musl-*_eabi/linux-mvebu`/zImage-initramfs-armada-385-turris-omnia
 	[ \! -d ./logs ] || mv ./logs ./logs-initram
 	cp build_dir/target-arm_*/linux-mvebu/zImage-initramfs-armada-385-turris-omnia bin/mvebu-musl/omnia-initramfs-zimage
-	[ "`du -b bin/mvebu-musl/omnia-initramfs-zimage | sed 's|[[:blank:]].*||'`" -lt 7000000 ] || exit 1
+	SIZE="`du -b bin/mvebu-musl/omnia-initramfs-zimage | sed 's|[[:blank:]].*||'`"
+	echo "Rescue image size is ${SIZE}."
+	if [ "$SIZE" -ge $(( 7 * 1024 * 1024 )) ]; then
+		echo FATAL: Image too big.
+		exit 1
+	fi
 	mv build_dir/uboot* bin/mvebu-musl
 	mkdir -p bin/mvebu-musl/x86-64
 	cp build_dir/host/uboot-turris-omnia*/turris-omnia-uboot/* bin/mvebu-musl/x86-64

--- a/configs/config-omnia-rescue
+++ b/configs/config-omnia-rescue
@@ -4795,3 +4795,4 @@ CONFIG_PACKAGE_uboot-envtools=y
 # CONFIG_PACKAGE_yanglint is not set
 # CONFIG_PACKAGE_yunbridge is not set
 # CONFIG_PACKAGE_zsh is not set
+CONFIG_PACKAGE_dropbear=y


### PR DESCRIPTION
This patch adds dropbear package into omnia-rescue. Resulting image is
bigger than 7 MB (SI) but still smaller than 7 MiB, which is the size of
the NOR partition. I fixed the compile_fw script so it compares the size
properly.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>