### PR TITLE
compile_fw: Fix build without signatures

### DIFF
--- a/compile_fw
+++ b/compile_fw
@@ -271,7 +271,9 @@ done
 if [ "$TARGET_BOARD" = "omnia" ]; then
 	rm -f $PUB_BIN_DIR/*.ext4 $PUB_BIN_DIR/*sums
 	for i in $PUB_BIN_DIR/medkit/*.tar.gz; do
-		staging_dir/host/bin/usign -S -m "$i" -s "$HOME"/mime.key
+		if [ -f "$HOME"/mime.key ]; then
+			staging_dir/host/bin/usign -S -m "$i" -s "$HOME"/mime.key
+		fi
 		pushd "`dirname $i`"
 		md5sum "`basename $i`" > "`basename $i`".md5
 		sha256sum "`basename $i`" > "`basename $i`".sha256


### PR DESCRIPTION
When there is no `mime.key` file in the user home directory, the build of
omnia firmware fails. This fixes it.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>