### PR TITLE
base-files: fix missing uci commit in led_autoconfig

### DIFF
--- a/package/base-files/files/etc/init.d/led_autoconfig
+++ b/package/base-files/files/etc/init.d/led_autoconfig
@@ -46,6 +46,8 @@ start() {
 			uci set system.@led[$i].trigger="${MSATA}"
 			uci delete system.@led[$i].dev 2> /dev/null
 			uci delete system.@led[$i].mode 2> /dev/null
+			uci commit system
+			break
 		done
 	fi
 }


### PR DESCRIPTION
There was missing uci commit after configuring of mSATA device LED.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>