### PR TITLE
tools: mkimage: fix build with OpenSSL 1.1.x

### DIFF
--- a/tools/mkimage/patches/210-openssl-1.1.x-compat.patch
+++ b/tools/mkimage/patches/210-openssl-1.1.x-compat.patch
@@ -1,0 +1,97 @@
+--- a/lib/rsa/rsa-sign.c
++++ b/lib/rsa/rsa-sign.c
+@@ -15,10 +15,25 @@
+ #include <openssl/ssl.h>
+ #include <openssl/evp.h>
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
++#if OPENSSL_VERSION_NUMBER < 0x10000000L
++#define HAVE_ERR_REMOVE_STATE
++#elif OPENSSL_VERSION_NUMBER < 0x10100000L
+ #define HAVE_ERR_REMOVE_THREAD_STATE
+ #endif
+ 
++#if (OPENSSL_VERSION_NUMBER < 0x10100005L) || defined(LIBRESSL_VERSION_NUMBER)
++static void RSA_get0_key(const RSA *r,
++                         const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
++{
++   if (n != NULL)
++       *n = r->n;
++   if (e != NULL)
++       *e = r->e;
++   if (d != NULL)
++       *d = r->d;
++}
++#endif
++
+ static int rsa_err(const char *msg)
+ {
+ 	unsigned long sslErr = ERR_get_error();
+@@ -154,7 +169,8 @@ static void rsa_remove(void)
+ 	ERR_free_strings();
+ #ifdef HAVE_ERR_REMOVE_THREAD_STATE
+ 	ERR_remove_thread_state(NULL);
+-#else
++#endif
++#ifdef HAVE_ERR_REMOVE_STATE
+ 	ERR_remove_state(0);
+ #endif
+ 	EVP_cleanup();
+@@ -210,7 +226,6 @@ static int rsa_sign_with_key(RSA *rsa, s
+ 		ret = rsa_err("Could not obtain signature");
+ 		goto err_sign;
+ 	}
+-	EVP_MD_CTX_cleanup(context);
+ 	EVP_MD_CTX_destroy(context);
+ 	EVP_PKEY_free(key);
+ 
+@@ -270,23 +285,26 @@ static int rsa_get_exponent(RSA *key, ui
+ 	BIGNUM *bn_te;
+ 	uint64_t te;
+ 
++	const BIGNUM *bn_e;
++	RSA_get0_key(key, NULL, &bn_e, NULL);
++
+ 	ret = -EINVAL;
+ 	bn_te = NULL;
+ 
+ 	if (!e)
+ 		goto cleanup;
+ 
+-	if (BN_num_bits(key->e) > 64)
++	if (BN_num_bits(bn_e) > 64)
+ 		goto cleanup;
+ 
+-	*e = BN_get_word(key->e);
++	*e = BN_get_word(bn_e);
+ 
+-	if (BN_num_bits(key->e) < 33) {
++	if (BN_num_bits(bn_e) < 33) {
+ 		ret = 0;
+ 		goto cleanup;
+ 	}
+ 
+-	bn_te = BN_dup(key->e);
++	bn_te = BN_dup(bn_e);
+ 	if (!bn_te)
+ 		goto cleanup;
+ 
+@@ -319,6 +337,9 @@ int rsa_get_params(RSA *key, uint64_t *e
+ 	BN_CTX *bn_ctx = BN_CTX_new();
+ 	int ret = 0;
+ 
++	const BIGNUM *bn_n;
++	RSA_get0_key(key, &bn_n, NULL, NULL);
++
+ 	/* Initialize BIGNUMs */
+ 	big1 = BN_new();
+ 	big2 = BN_new();
+@@ -337,7 +358,7 @@ int rsa_get_params(RSA *key, uint64_t *e
+ 	if (0 != rsa_get_exponent(key, exponent))
+ 		ret = -1;
+ 
+-	if (!BN_copy(n, key->n) || !BN_set_word(big1, 1L) ||
++	if (!BN_copy(n, bn_n) || !BN_set_word(big1, 1L) ||
+ 	    !BN_set_word(big2, 2L) || !BN_set_word(big32, 32L))
+ 		ret = -1;
+ 


### PR DESCRIPTION
This commit adds patch to fix build of mkimage package in cases where OpenSSL library newer than 1.0.0 is present in host system.

Original patch source is from upstream LEDE repo:
[tools: mkimage: fix build with OpenSSL 1.1.x](https://github.com/lede-project/source/commit/70b104f98c0657323b28fce140b73a94bf3eb756)

Signed-off-by: Vladimir Zahradnik <vladimir.zahradnik@gmail.com>