### PR TITLE
Enable to set local dns server for turris

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -624,8 +624,8 @@ start_service() {
 	[ $ADD_LOCAL_DOMAIN -eq 1 ] && [ -n "$DOMAIN" ] && {
 		echo "search $DOMAIN" >> /tmp/resolv.conf
 	}
-	DNS_SERVERS="$DNS_SERVERS 127.0.0.1"
-	for DNS_SERVER in $DNS_SERVERS ; do
+	CUSTOM_DNS=$(uci_get dhcp @dnsmasq[0] local_dns_server "$DNS_SERVERS 127.0.0.1")
+	for DNS_SERVER in $CUSTOM_DNS; do
 		echo "nameserver $DNS_SERVER" >> /tmp/resolv.conf
 	done
 }


### PR DESCRIPTION
Enables to overwrite the dns server set by dnsmasq in /tmp/resolv.conf (/etc/resolv.conf). 
To do so someone has to set the option `list local_dns_server <DNS_SERVER>` (replace `<DNS_SERVER>` with an actual dns server) in the dnsmasq section of /etc/config/dhcp. 
If the option is missing in the conf file it defaults to the current method (using 127.0.0.1)